### PR TITLE
Bug with the network field

### DIFF
--- a/AudiosearchNet.Tests/.gitignore
+++ b/AudiosearchNet.Tests/.gitignore
@@ -1,0 +1,2 @@
+
+TestHelper.cs

--- a/AudiosearchNet.Tests/AudiosearchNet.Tests.csproj
+++ b/AudiosearchNet.Tests/AudiosearchNet.Tests.csproj
@@ -51,6 +51,7 @@
   <ItemGroup>
     <Compile Include="AudiosearchNetUnitTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestHelper.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/AudiosearchNet.Tests/AudiosearchNetUnitTest.cs
+++ b/AudiosearchNet.Tests/AudiosearchNetUnitTest.cs
@@ -2,31 +2,37 @@
 
 namespace AudiosearchNet.Tests
 {
-    [TestClass]
-    public class AudiosearchNetUnitTest
-    {
-        private AudiosearchNetClient client;
+	[TestClass]
+	public class AudiosearchNetUnitTest
+	{
+		private AudiosearchNetClient client;
 
-        public AudiosearchNetUnitTest()
-        {
-            client = new AudiosearchNetClient(
-                    "[YOUR APPLICATION ID]",
-                    "[YOUR APPLICATION SECRET]"
-                );
-        }
+		public AudiosearchNetUnitTest()
+		{
+			client = TestHelper.CreateAudiosearchNetClient();
 
-        [TestMethod]
-        public void AudiosearchNetClient_Authorize()
-        {
-            Assert.IsNotNull(client.AccessToken, "Failed: Access Token cannot be null.");
-        }
+		}
 
-        [TestMethod]
-        public void AudiosearchNetClient_GetShowsByKeyWords()
-        {
-            var shows = client.GetShowsByKeyWords("Jovem Nerd");
+		[TestMethod]
+		public void AudiosearchNetClient_Authorize()
+		{
+			Assert.IsNotNull(client.AccessToken, "Failed: Access Token cannot be null.");
+		}
 
-            Assert.IsNotNull(shows);
-        }
-    }
+		[TestMethod]
+		public void AudiosearchNetClient_GetShowsByKeyWords()
+		{
+			var shows = client.GetShowsByKeyWords("Jovem Nerd");
+
+			Assert.IsNotNull(shows);
+		}
+
+		[TestMethod]
+		public void AudiosearchNetClient_GetShowsByKeyWordsWithNetworkFieldFilled()
+		{
+			var shows = client.GetShowsByKeyWords("Savage Love");
+
+			Assert.IsNotNull(shows);
+		}
+	}
 }

--- a/AudiosearchNet/AudiosearchNet.csproj
+++ b/AudiosearchNet/AudiosearchNet.csproj
@@ -61,6 +61,7 @@
     <Compile Include="Models\Episode.cs" />
     <Compile Include="Models\Query.cs" />
     <Compile Include="Models\Show.cs" />
+    <Compile Include="Models\Network.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/AudiosearchNet/Models/Network.cs
+++ b/AudiosearchNet/Models/Network.cs
@@ -1,0 +1,13 @@
+﻿using Newtonsoft.Json;
+
+namespace AudiosearchNet.Models
+{
+    public class Network
+    {
+        [JsonProperty("id")]
+        public int Id { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+    }
+}

--- a/AudiosearchNet/Models/Show.cs
+++ b/AudiosearchNet/Models/Show.cs
@@ -12,7 +12,7 @@ namespace AudiosearchNet.Models
         public string Title { get; set; }
 
         [JsonProperty("network")]
-        public string Network { get; set; }
+        public Network Network { get; set; }
 
         [JsonProperty("categories")]
         public List<Category> Categories { get; set; }


### PR DESCRIPTION
This change changes the network field from a string to a new Network class. There is a test added that exploits this and I've moved the credentials into a separate file to the test to minimise the chance that people will commit their own secret.